### PR TITLE
added a parameter to allow overriding the path where the codegen.yml will be searched for

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ codegen({
   enableWatcher: true,
   /* Allows overriding codegen configuration options in the context of this plugin. Useful if you prefer a cleaner log by passing { errorsOnly: true }. */
   configOverride: CodegenConfig,
+  /* Allows you to point to a non-standard config path location. Defaults to codegen.yml */
+  configPath: 'codegen.yml',
   /* Enable plugin logging to assist in debugging. Defaults to false. */
   debug: false,
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,11 @@ export interface Options {
    */
   enableWatcher?: boolean;
   /**
+   * Allows you to point to a non-standard config path location
+   * @defaultValue `codegen.yml`
+   */
+  configPath?: string;
+  /**
    * Override codegen configuration just for this plugin.
    */
   configOverride?: Partial<Types.Config>;
@@ -46,6 +51,7 @@ export default function VitePluginGraphQLCodegen(options?: Options): Plugin {
     runOnStart = true,
     runOnBuild = true,
     enableWatcher = true,
+    configPath = "codegen.yml",
     configOverride = {},
     debug = false,
   } = options ?? {};
@@ -61,7 +67,7 @@ export default function VitePluginGraphQLCodegen(options?: Options): Plugin {
     name: 'graphql-codegen',
     async config(config, env) {
       log('Loading codegen context');
-      codegenContext = await loadContext(config.root);
+      codegenContext = await loadContext(config.root + options.configPath);
       log('Codegen context loaded');
 
       // Vite handles file watching

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export default function VitePluginGraphQLCodegen(options?: Options): Plugin {
     name: 'graphql-codegen',
     async config(config, env) {
       log('Loading codegen context');
-      codegenContext = await loadContext(config.root + options.configPath);
+      codegenContext = await loadContext(config.root + '/' + options.configPath);
       log('Codegen context loaded');
 
       // Vite handles file watching


### PR DESCRIPTION
see issue related to this PR
https://github.com/danielwaltz/vite-plugin-graphql-codegen/issues/1