### PR TITLE
fix: fix watching schema while also watching documents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,7 @@ export default function VitePluginGraphQLCodegen(options?: Options): Plugin {
             );
             log('Document check successful in file watcher');
 
-            if (!isDocument) return;
+            if (!isDocument && !matchOnSchemas) return;
 
             log('File matched a graphql document');
           } catch (error) {


### PR DESCRIPTION
Currently if you are watching both and the schema changes it exits early since the schema isn't considered a document.

Now if both are enabled and the file is not a document it will not return early if it should also check if it is a schema which resolved the issue of it not regenerating on schema changes for me.