### PR TITLE
Add ESM export

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "vite-plugin",
     "vite-plugin-graphql-codegen"
   ],
-  "type": "commonjs",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,14 +6,16 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   skipNodeModulesBundle: true,
-  format: ['cjs'],
+  format: ['cjs', 'esm'],
   esbuildOptions: (options) => {
-    options.footer = {
-      // This will ensure we can continue writing this plugin
-      // as a modern ECMA module, while still publishing this as a CommonJS
-      // library with a default export, as that's how ESLint expects plugins to look.
-      // @see https://github.com/evanw/esbuild/issues/1182#issuecomment-1011414271
-      js: 'module.exports = module.exports.default;',
-    };
+    if (options.format === 'cjs') {
+      options.footer = {
+        // This will ensure we can continue writing this plugin
+        // as a modern ECMA module, while still publishing this as a CommonJS
+        // library with a default export, as that's how ESLint expects plugins to look.
+        // @see https://github.com/evanw/esbuild/issues/1182#issuecomment-1011414271
+        js: 'module.exports = module.exports.default;',
+      };
+    }
   },
 });


### PR DESCRIPTION
Vite 5 prints warnings for any plugins still using CJS imports. This PR adds an ESM export, which resolves the warning.

```
Trace: The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
    at warnCjsUsage (/redacted/node_modules/vite/index.cjs:32:3)
    at Object.<anonymous> (/redacted/node_modules/vite/index.cjs:3:1)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at Object.<anonymous> (/redacted/node_modules/vite-plugin-graphql-codegen/dist/index.js:29:20)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
```