### PR TITLE
fix: watch documents and schemas from nested config

### DIFF
--- a/src/utils/configPaths.ts
+++ b/src/utils/configPaths.ts
@@ -1,4 +1,5 @@
 import { normalizePath } from 'vite';
+import { resolve } from 'node:path';
 import type { CodegenContext } from '@graphql-codegen/cli';
 
 export async function getDocumentPaths(
@@ -52,5 +53,6 @@ export async function getSchemaPaths(
   return schemas
     .filter((schema): schema is string => typeof schema === 'string')
     .filter(Boolean)
+    .map((schema) => resolve(schema))
     .map(normalizePath);
 }

--- a/src/utils/configPaths.ts
+++ b/src/utils/configPaths.ts
@@ -1,15 +1,24 @@
 import { normalizePath } from 'vite';
 import type { CodegenContext } from '@graphql-codegen/cli';
-import { normalizeInstanceOrArray } from '@graphql-codegen/plugin-helpers';
 
 export async function getDocumentPaths(
   context: CodegenContext,
 ): Promise<string[]> {
   const config = context.getConfig();
 
-  if (!config.documents) return [];
+  const sourceDocuments = Object.values(config.generates).map((output) =>
+    Array.isArray(output) ? undefined : output.documents,
+  );
 
-  const normalized = normalizeInstanceOrArray(config.documents);
+  if (config.documents) {
+    sourceDocuments.unshift(config.documents);
+  }
+
+  const normalized = sourceDocuments
+    .filter((item): item is NonNullable<typeof item> => !!item)
+    .flat();
+
+  if (!normalized.length) return [];
 
   const documents = await context.loadDocuments(normalized);
 
@@ -26,9 +35,19 @@ export async function getSchemaPaths(
 ): Promise<string[]> {
   const config = context.getConfig();
 
-  if (!config.schema) return [];
+  const sourceSchemas = Object.values(config.generates).map((output) =>
+    Array.isArray(output) ? undefined : output.schema,
+  );
 
-  const schemas = normalizeInstanceOrArray(config.schema);
+  if (config.schema) {
+    sourceSchemas.unshift(config.schema);
+  }
+
+  const schemas = sourceSchemas
+    .filter((item): item is NonNullable<typeof item> => !!item)
+    .flat();
+
+  if (!schemas.length) return [];
 
   return schemas
     .filter((schema): schema is string => typeof schema === 'string')


### PR DESCRIPTION
Search and collect nested configuration for `documents` and `schema` props for make them available for file watcher.

This fixes https://github.com/danielwaltz/vite-plugin-graphql-codegen/issues/24 and https://github.com/danielwaltz/vite-plugin-graphql-codegen/issues/12