### PR TITLE
fix: matching files for watcher

### DIFF
--- a/src/utils/fileMatchers.ts
+++ b/src/utils/fileMatchers.ts
@@ -20,7 +20,7 @@ export const isGraphQLDocument: FileMatcher = async (filePath, context) => {
 
   const normalizedFilePath = normalizePath(filePath);
 
-  return documentPaths.some((path) => normalizedFilePath.includes(path));
+  return documentPaths.includes(normalizedFilePath);
 };
 
 export const isGraphQLSchema: FileMatcher = async (filePath, context) => {
@@ -30,5 +30,5 @@ export const isGraphQLSchema: FileMatcher = async (filePath, context) => {
 
   const normalizedFilePath = normalizePath(filePath);
 
-  return schemaPaths.some((path) => normalizedFilePath.includes(path));
+  return schemaPaths.includes(normalizedFilePath);
 };


### PR DESCRIPTION
Currently, if you have a glob pattern such as `src/**/*.graphql`, modifying `src/path/api.graphql.generated.ts` will result in a false positive check and trigger watcher for that file. This PR fixes such cases.