### PR TITLE
chore: improve debug log readability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,13 @@ export function GraphQLCodegen(options?: Options): Plugin {
         throw error;
       }
 
+      if (!matchOnDocuments) {
+        log(`File watcher for documents is disabled by config`);
+      }
+      if (!matchOnSchemas) {
+        log(`File watcher for schemas is disabled by config`);
+      }
+
       viteMode = env.command;
     },
     async buildStart() {
@@ -182,8 +189,6 @@ export function GraphQLCodegen(options?: Options): Plugin {
       if (!enableWatcher) return;
 
       const listener = async (filePath = '') => {
-        log('File changed:', filePath);
-
         const isConfig = await isCodegenConfig(filePath, codegenContext);
 
         if (isConfig) {
@@ -204,22 +209,17 @@ export function GraphQLCodegen(options?: Options): Plugin {
         const matcherResults = await Promise.all(
           matchers.map(async ([enabled, name, matcher]) => {
             if (!enabled) {
-              log(`Check for ${name} file skipped in file watcher by config`);
               return false;
             }
 
             try {
               const isMatch = await matcher(filePath, codegenContext);
-
-              log(`Check for ${name} file successful in file watcher`);
-
-              if (isMatch) log(`File matched a graphql ${name}`);
-              else log(`File did not match a graphql ${name}`);
+              if (isMatch) log(`Graphql ${name} file matched: ${filePath}`);
 
               return isMatch;
             } catch (error) {
               // GraphQL Codegen handles logging useful errors
-              log(`Check for ${name} file failed in file watcher`);
+              log(`Check for ${name} file failed in file watcher: ${filePath}`);
               return false;
             }
           }),


### PR DESCRIPTION
Currently, the debug log is a bit unusable, as it contanins a lot of records which is not related to plugin: modyfing any file in proect produses ~5 log entries. Below are screenshots of the same number of interactions with project files demonstrating this. This PR reduce amount of log records.


### Before

<img width="841" alt="image" src="https://github.com/danielwaltz/vite-plugin-graphql-codegen/assets/4581398/a470a29b-6fcf-42ab-a29a-9e82c4e8c759">

### After
<img width="833" alt="image" src="https://github.com/danielwaltz/vite-plugin-graphql-codegen/assets/4581398/d41c5870-a811-41d3-8132-66c15020d188">
