### PR TITLE
chore: rewrite file watcher

### DIFF
--- a/src/utils/fileMatchers.ts
+++ b/src/utils/fileMatchers.ts
@@ -1,34 +1,15 @@
 import { normalizePath } from 'vite';
-import type { CodegenContext } from '@graphql-codegen/cli';
-import { getDocumentPaths, getSchemaPaths } from '../utils/configPaths';
 
-export type FileMatcher = (
-  filePath: string,
-  context: CodegenContext,
-) => Promise<boolean>;
+export const isCodegenConfig = (filePath: string, configPath?: string) => {
+  if (!configPath) return false;
 
-export const isCodegenConfig: FileMatcher = async (filePath, context) => {
-  if (!context.filepath) return false;
-
-  return normalizePath(filePath) === normalizePath(context.filepath);
+  return normalizePath(filePath) === normalizePath(configPath);
 };
 
-export const isGraphQLDocument: FileMatcher = async (filePath, context) => {
-  const documentPaths = await getDocumentPaths(context);
-
-  if (!documentPaths.length) return false;
+export const isFileMatched = (filePath: string, lookupPaths: string[]) => {
+  if (!lookupPaths.length) return false;
 
   const normalizedFilePath = normalizePath(filePath);
 
-  return documentPaths.some((path) => normalizedFilePath.includes(path));
-};
-
-export const isGraphQLSchema: FileMatcher = async (filePath, context) => {
-  const schemaPaths = await getSchemaPaths(context);
-
-  if (!schemaPaths.length) return false;
-
-  const normalizedFilePath = normalizePath(filePath);
-
-  return schemaPaths.some((path) => normalizedFilePath.includes(path));
+  return lookupPaths.includes(normalizedFilePath);
 };


### PR DESCRIPTION
Currently, file watcher asynchronously retrieves documents and schemas on **each** project file changes, which is slow, and caused unreasonably high resources usage.

### Changes made
- resolve all configured documents and schemas only once on server startup and simply check file path matching in watcher. 
- fix cases when schema path defined with dot like `./src/schema.graphql` by resolve absolute schema paths.
- fix cases when documents defined with glob pattern like `./src/**/*.graphql`, and modifying `src/path/api.graphql.generated.ts` file caused false positive check and trigger watcher for that file.

Also, this PR should resolve OOM issues reported in https://github.com/danielwaltz/vite-plugin-graphql-codegen/issues/27

### Side changes
- reduce amount of log records, as currently it contains a lot of records which is not related to plugin: modifying any file in project produces ~5 log entries. Below are screenshots of the same number of interactions with project files demonstrating this.

### Before
<img width="841" alt="image" src="https://github.com/danielwaltz/vite-plugin-graphql-codegen/assets/4581398/a470a29b-6fcf-42ab-a29a-9e82c4e8c759">

### After
<img width="833" alt="image" src="https://github.com/danielwaltz/vite-plugin-graphql-codegen/assets/4581398/d41c5870-a811-41d3-8132-66c15020d188">
